### PR TITLE
Globally configurable results limiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Extends the `Regexp` class with the methods: `Regexp#examples` and `Regexp#rando
 
 \* If the regex has an infinite number of possible strings that match it, such as `/a*b+c{2,}/`,
 or a huge number of possible matches, such as `/.\w/`, then only a subset of these will be listed.
-
 For more detail on this, see [configuration options](#configuration-options).
 
 If you'd like to understand how/why this gem works, please check out my [blog post](https://tom-lord.github.io/Reverse-Engineering-Regular-Expressions/) about it.
@@ -149,7 +148,15 @@ When generating examples, the gem uses 3 configurable values to limit how many e
 
 `Rexexp#examples` makes use of *all* these options; `Rexexp#random_example` only uses `max_repeater_variance`, since the other options are redundant.
 
-To use an alternative value, simply pass the configuration option as follows:
+To use an alternative value, you can either define a different default value:
+
+```ruby
+RegexpExamples::ResultCountLimiters.max_repeater_variance = 5
+RegexpExamples::ResultCountLimiters.max_group_results = 10
+RegexpExamples::ResultCountLimiters.max_results_limit = 20000
+```
+
+Or, simply pass the configuration option as a parameter:
 
 ```ruby
 /a*/.examples(max_repeater_variance: 5)

--- a/README.md
+++ b/README.md
@@ -148,15 +148,9 @@ When generating examples, the gem uses 3 configurable values to limit how many e
 
 `Rexexp#examples` makes use of *all* these options; `Rexexp#random_example` only uses `max_repeater_variance`, since the other options are redundant.
 
-To use an alternative value, you can either define a different default value:
+### Defining custom configuration values
 
-```ruby
-RegexpExamples::ResultCountLimiters.max_repeater_variance = 5
-RegexpExamples::ResultCountLimiters.max_group_results = 10
-RegexpExamples::ResultCountLimiters.max_results_limit = 20000
-```
-
-Or, simply pass the configuration option as a parameter:
+To use an alternative value, you can either pass the configuration option as a parameter:
 
 ```ruby
 /a*/.examples(max_repeater_variance: 5)
@@ -169,6 +163,24 @@ Or, simply pass the configuration option as a parameter:
   #=> "A very unlikely result!"
 ```
 
+Or, set an alternative value *within a block*:
+
+```ruby
+RegexpExamples::Config.with_configuration(max_repeater_variance: 5) do
+  # ...
+end
+```
+
+Or, globally set a different default value:
+
+```ruby
+# e.g In a rails project, you may wish to place this in
+# config/initializers/regexp_examples.rb
+RegexpExamples::Config.max_repeater_variance = 5
+RegexpExamples::Config.max_group_results = 10
+RegexpExamples::Config.max_results_limit = 20000
+```
+
 A sensible use case might be, for example, to generate all 1-5 digit strings:
 
 ```ruby
@@ -176,11 +188,15 @@ A sensible use case might be, for example, to generate all 1-5 digit strings:
   #=> ['0', '1', '2', ..., '99998', '99999']
 ```
 
+### Configuration Notes
+
 Due to code optimisation, `Regexp#random_example` runs pretty fast even on very complex patterns.
 (I.e. It's typically a _lot_ faster than using `/pattern/.examples.sample(1)`.)
 For instance, the following takes no more than ~ 1 second on my machine:
 
 `/.*\w+\d{100}/.random_example(max_repeater_variance: 1000)`
+
+All forms of configuration mentioned above **are thread safe**.
 
 ## Bugs and TODOs
 

--- a/lib/core_extensions/regexp/examples.rb
+++ b/lib/core_extensions/regexp/examples.rb
@@ -5,19 +5,21 @@ module CoreExtensions
     # No core classes are extended in any way, other than the above two methods.
     module Examples
       def examples(**config_options)
-        RegexpExamples::ResultCountLimiters.configure!(
+        RegexpExamples::ResultCountLimiters.with_configuration(
           max_repeater_variance: config_options[:max_repeater_variance],
           max_group_results: config_options[:max_group_results],
           max_results_limit: config_options[:max_results_limit]
-        )
-        examples_by_method(:result)
+        ) do
+          examples_by_method(:result)
+        end
       end
 
       def random_example(**config_options)
-        RegexpExamples::ResultCountLimiters.configure!(
+        RegexpExamples::ResultCountLimiters.with_configuration(
           max_repeater_variance: config_options[:max_repeater_variance]
-        )
-        examples_by_method(:random_result).sample(1).first
+        ) do
+          examples_by_method(:random_result).sample
+        end
       end
 
       private

--- a/lib/core_extensions/regexp/examples.rb
+++ b/lib/core_extensions/regexp/examples.rb
@@ -5,19 +5,13 @@ module CoreExtensions
     # No core classes are extended in any way, other than the above two methods.
     module Examples
       def examples(**config_options)
-        RegexpExamples::ResultCountLimiters.with_configuration(
-          max_repeater_variance: config_options[:max_repeater_variance],
-          max_group_results: config_options[:max_group_results],
-          max_results_limit: config_options[:max_results_limit]
-        ) do
+        RegexpExamples::Config.with_configuration(config_options) do
           examples_by_method(:result)
         end
       end
 
       def random_example(**config_options)
-        RegexpExamples::ResultCountLimiters.with_configuration(
-          max_repeater_variance: config_options[:max_repeater_variance]
-        ) do
+        RegexpExamples::Config.with_configuration(config_options) do
           examples_by_method(:random_result).sample
         end
       end

--- a/lib/regexp-examples/constants.rb
+++ b/lib/regexp-examples/constants.rb
@@ -33,7 +33,11 @@ module RegexpExamples
       end
 
       def config
-        Thread.current[:regexp_examples_config] ||= {}
+        Thread.current[:regexp_examples_config] ||= {
+          max_repeater_variance: MAX_REPEATER_VARIANCE_DEFAULT,
+          max_group_results: MAX_GROUP_RESULTS_DEFAULT,
+          max_results_limit: MAX_RESULTS_LIMIT_DEFAULT
+        }
       end
     end
     # The maximum variance for any given repeater, to prevent a huge/infinite number of
@@ -44,21 +48,18 @@ module RegexpExamples
     # .{,3} is equivalent to .{0,2}
     # .{3,8} is equivalent to .{3,5}
     MAX_REPEATER_VARIANCE_DEFAULT = 2
-    self.max_repeater_variance = MAX_REPEATER_VARIANCE_DEFAULT
 
     # Maximum number of characters returned from a char set, to reduce output spam
     # For example, if self.max_group_results = 5 then:
     # \d is equivalent to [01234]
     # \w is equivalent to [abcde]
     MAX_GROUP_RESULTS_DEFAULT = 5
-    self.max_group_results = MAX_GROUP_RESULTS_DEFAULT
 
     # Maximum number of results to be generated, for Regexp#examples
     # This is to prevent the system "freezing" when given instructions like:
     # /[ab]{30}/.examples
     # (Which would attempt to generate 2**30 == 1073741824 examples!!!)
     MAX_RESULTS_LIMIT_DEFAULT = 10_000
-    self.max_results_limit = MAX_RESULTS_LIMIT_DEFAULT
   end
 
   # Definitions of various special characters, used in regular expressions.

--- a/lib/regexp-examples/constants.rb
+++ b/lib/regexp-examples/constants.rb
@@ -2,6 +2,28 @@
 module RegexpExamples
   # Configuration settings to limit the number/length of Regexp examples generated
   class ResultCountLimiters
+    class << self
+      attr_accessor :max_repeater_variance, :max_group_results, :max_results_limit
+      def with_configuration(max_repeater_variance: nil,
+                            max_group_results: nil,
+                            max_results_limit: nil)
+        original_vals = [
+          @max_repeater_variance,
+          @max_group_results,
+          @max_results_limit
+        ]
+
+        @max_repeater_variance = max_repeater_variance if max_repeater_variance
+        @max_group_results = max_group_results if max_group_results
+        @max_results_limit = max_results_limit if max_results_limit
+
+        result = yield
+
+        @max_repeater_variance, @max_group_results, @max_results_limit = *original_vals
+
+        result
+      end
+    end
     # The maximum variance for any given repeater, to prevent a huge/infinite number of
     # examples from being listed. For example, if @@max_repeater_variance = 2 then:
     # .* is equivalent to .{0,2}
@@ -10,28 +32,21 @@ module RegexpExamples
     # .{,3} is equivalent to .{0,2}
     # .{3,8} is equivalent to .{3,5}
     MAX_REPEATER_VARIANCE_DEFAULT = 2
+    @max_repeater_variance = MAX_REPEATER_VARIANCE_DEFAULT
 
     # Maximum number of characters returned from a char set, to reduce output spam
     # For example, if @@max_group_results = 5 then:
     # \d is equivalent to [01234]
     # \w is equivalent to [abcde]
     MAX_GROUP_RESULTS_DEFAULT = 5
+    @max_group_results = MAX_GROUP_RESULTS_DEFAULT
 
     # Maximum number of results to be generated, for Regexp#examples
     # This is to prevent the system "freezing" when given instructions like:
     # /[ab]{30}/.examples
     # (Which would attempt to generate 2**30 == 1073741824 examples!!!)
     MAX_RESULTS_LIMIT_DEFAULT = 10_000
-    class << self
-      attr_reader :max_repeater_variance, :max_group_results, :max_results_limit
-      def configure!(max_repeater_variance: nil,
-                     max_group_results: nil,
-                     max_results_limit: nil)
-        @max_repeater_variance = (max_repeater_variance || MAX_REPEATER_VARIANCE_DEFAULT)
-        @max_group_results = (max_group_results || MAX_GROUP_RESULTS_DEFAULT)
-        @max_results_limit = (max_results_limit || MAX_RESULTS_LIMIT_DEFAULT)
-      end
-    end
+    @max_results_limit = MAX_RESULTS_LIMIT_DEFAULT
   end
 
   def self.max_repeater_variance

--- a/lib/regexp-examples/constants.rb
+++ b/lib/regexp-examples/constants.rb
@@ -1,64 +1,76 @@
 # :nodoc:
 module RegexpExamples
   # Configuration settings to limit the number/length of Regexp examples generated
-  class ResultCountLimiters
+  class Config
     class << self
-      attr_accessor :max_repeater_variance, :max_group_results, :max_results_limit
-      def with_configuration(max_repeater_variance: nil,
-                            max_group_results: nil,
-                            max_results_limit: nil)
-        original_vals = [
-          @max_repeater_variance,
-          @max_group_results,
-          @max_results_limit
-        ]
+      def with_configuration(**new_config)
+        original_config = config.dup
 
-        @max_repeater_variance = max_repeater_variance if max_repeater_variance
-        @max_group_results = max_group_results if max_group_results
-        @max_results_limit = max_results_limit if max_results_limit
-
-        result = yield
-
-        @max_repeater_variance, @max_group_results, @max_results_limit = *original_vals
+        begin
+          self.config = new_config
+          result = yield
+        ensure
+          self.config = original_config
+        end
 
         result
       end
+
+      # Thread-safe getters and setters
+      %i[max_repeater_variance max_group_results max_results_limit].each do |m|
+        define_method(m) do
+          config[m]
+        end
+        define_method("#{m}=") do |value|
+          config[m] = value
+        end
+      end
+
+      private
+
+      def config=(**args)
+        Thread.current[:regexp_examples_config].merge!(args)
+      end
+
+      def config
+        Thread.current[:regexp_examples_config] ||= {}
+      end
     end
     # The maximum variance for any given repeater, to prevent a huge/infinite number of
-    # examples from being listed. For example, if @@max_repeater_variance = 2 then:
+    # examples from being listed. For example, if self.max_repeater_variance = 2 then:
     # .* is equivalent to .{0,2}
     # .+ is equivalent to .{1,3}
     # .{2,} is equivalent to .{2,4}
     # .{,3} is equivalent to .{0,2}
     # .{3,8} is equivalent to .{3,5}
     MAX_REPEATER_VARIANCE_DEFAULT = 2
-    @max_repeater_variance = MAX_REPEATER_VARIANCE_DEFAULT
+    self.max_repeater_variance = MAX_REPEATER_VARIANCE_DEFAULT
 
     # Maximum number of characters returned from a char set, to reduce output spam
-    # For example, if @@max_group_results = 5 then:
+    # For example, if self.max_group_results = 5 then:
     # \d is equivalent to [01234]
     # \w is equivalent to [abcde]
     MAX_GROUP_RESULTS_DEFAULT = 5
-    @max_group_results = MAX_GROUP_RESULTS_DEFAULT
+    self.max_group_results = MAX_GROUP_RESULTS_DEFAULT
 
     # Maximum number of results to be generated, for Regexp#examples
     # This is to prevent the system "freezing" when given instructions like:
     # /[ab]{30}/.examples
     # (Which would attempt to generate 2**30 == 1073741824 examples!!!)
     MAX_RESULTS_LIMIT_DEFAULT = 10_000
-    @max_results_limit = MAX_RESULTS_LIMIT_DEFAULT
+    self.max_results_limit = MAX_RESULTS_LIMIT_DEFAULT
   end
 
   def self.max_repeater_variance
-    ResultCountLimiters.max_repeater_variance
+    Config.max_repeater_variance
   end
 
   def self.max_group_results
-    ResultCountLimiters.max_group_results
+    Config.max_group_results
   end
 
   def self.max_results_limit
-    ResultCountLimiters.max_results_limit
+    Config.max_results_limit
   end
 
   # Definitions of various special characters, used in regular expressions.

--- a/lib/regexp-examples/constants.rb
+++ b/lib/regexp-examples/constants.rb
@@ -61,18 +61,6 @@ module RegexpExamples
     self.max_results_limit = MAX_RESULTS_LIMIT_DEFAULT
   end
 
-  def self.max_repeater_variance
-    Config.max_repeater_variance
-  end
-
-  def self.max_group_results
-    Config.max_group_results
-  end
-
-  def self.max_results_limit
-    Config.max_results_limit
-  end
-
   # Definitions of various special characters, used in regular expressions.
   # For example, `/\h/.examples` will return the value of `Hex` in this module
   module CharSets

--- a/lib/regexp-examples/helpers.rb
+++ b/lib/regexp-examples/helpers.rb
@@ -10,10 +10,13 @@ module RegexpExamples
   # Edge case:
   # permutations_of_strings [ [] ] #=> nil
   # (For example, ths occurs during /[^\d\D]/.examples #=> [])
-  def self.permutations_of_strings(arrays_of_strings, max_results_limiter = MaxResultsLimiterByProduct.new)
+  def self.permutations_of_strings(arrays_of_strings,
+                                   max_results_limiter = MaxResultsLimiterByProduct.new)
     partial_result = max_results_limiter.limit_results(arrays_of_strings.shift)
     return partial_result if arrays_of_strings.empty?
-    partial_result.product(permutations_of_strings(arrays_of_strings, max_results_limiter)).map do |result|
+    partial_result.product(
+      permutations_of_strings(arrays_of_strings, max_results_limiter)
+    ).map do |result|
       join_preserving_capture_groups(result)
     end
   end

--- a/lib/regexp-examples/max_results_limiter.rb
+++ b/lib/regexp-examples/max_results_limiter.rb
@@ -25,7 +25,8 @@ module RegexpExamples
 
     def results_allowed_from(partial_results, limiter_method)
       partial_results.first(
-        RegexpExamples.max_results_limit.public_send(limiter_method, @results_count)
+        RegexpExamples::Config.max_results_limit
+          .public_send(limiter_method, @results_count)
       )
     end
   end

--- a/lib/regexp-examples/max_results_limiter.rb
+++ b/lib/regexp-examples/max_results_limiter.rb
@@ -1,5 +1,6 @@
 module RegexpExamples
-  class MaxResultsLimiter # Base class
+  # Abstract (base) class to assist limiting Regexp.examples max results
+  class MaxResultsLimiter
     def initialize(initial_results_count)
       @results_count = initial_results_count
     end

--- a/lib/regexp-examples/repeaters.rb
+++ b/lib/regexp-examples/repeaters.rb
@@ -10,7 +10,7 @@ module RegexpExamples
     end
 
     def result
-      group_results = group.result.first(RegexpExamples.max_group_results)
+      group_results = group.result.first(RegexpExamples::Config.max_group_results)
       results = []
       max_results_limiter = MaxResultsLimiterBySum.new
       min_repeats.upto(max_repeats) do |repeats|
@@ -51,7 +51,7 @@ module RegexpExamples
     def initialize(group)
       super
       @min_repeats = 0
-      @max_repeats = RegexpExamples.max_repeater_variance
+      @max_repeats = RegexpExamples::Config.max_repeater_variance
     end
   end
 
@@ -61,7 +61,7 @@ module RegexpExamples
     def initialize(group)
       super
       @min_repeats = 1
-      @max_repeats = RegexpExamples.max_repeater_variance + 1
+      @max_repeats = RegexpExamples::Config.max_repeater_variance + 1
     end
   end
 
@@ -81,9 +81,11 @@ module RegexpExamples
       super(group)
       @min_repeats = min || 0
       if max # e.g. {1,100} --> Treat as {1,3} (by default max_repeater_variance)
-        @max_repeats = smallest(max, @min_repeats + RegexpExamples.max_repeater_variance)
+        @max_repeats = smallest(
+          max, @min_repeats + RegexpExamples::Config.max_repeater_variance
+        )
       elsif has_comma # e.g. {2,} --> Treat as {2,4} (by default max_repeater_variance)
-        @max_repeats = @min_repeats + RegexpExamples.max_repeater_variance
+        @max_repeats = @min_repeats + RegexpExamples::Config.max_repeater_variance
       else # e.g. {3} --> Treat as {3,3}
         @max_repeats = @min_repeats
       end

--- a/lib/regexp-examples/repeaters.rb
+++ b/lib/regexp-examples/repeaters.rb
@@ -80,21 +80,14 @@ module RegexpExamples
     def initialize(group, min, has_comma, max)
       super(group)
       @min_repeats = min || 0
-      if max # e.g. {1,100} --> Treat as {1,3} (by default max_repeater_variance)
-        @max_repeats = smallest(
-          max, @min_repeats + RegexpExamples::Config.max_repeater_variance
-        )
-      elsif has_comma # e.g. {2,} --> Treat as {2,4} (by default max_repeater_variance)
-        @max_repeats = @min_repeats + RegexpExamples::Config.max_repeater_variance
-      else # e.g. {3} --> Treat as {3,3}
-        @max_repeats = @min_repeats
-      end
-    end
-
-    private
-
-    def smallest(x, y)
-      x < y ? x : y
+      @max_repeats = if !has_comma
+                       @min_repeats
+                     else
+                       [
+                         max,
+                         @min_repeats + RegexpExamples::Config.max_repeater_variance
+                       ].compact.min
+                     end
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe RegexpExamples::ResultCountLimiters do
+RSpec.describe RegexpExamples::Config do
 
   describe 'max_repeater_variance' do
     context 'as a passed parameter' do
@@ -38,11 +38,11 @@ RSpec.describe RegexpExamples::ResultCountLimiters do
 
     context 'as a global setting' do
       before do
-        @original = RegexpExamples::ResultCountLimiters.max_results_limit
-        RegexpExamples::ResultCountLimiters.max_results_limit = 5
+        @original = RegexpExamples::Config.max_results_limit
+        RegexpExamples::Config.max_results_limit = 5
       end
       after do
-        RegexpExamples::ResultCountLimiters.max_results_limit = @original
+        RegexpExamples::Config.max_results_limit = @original
       end
 
       it 'sets limit without passing explicitly' do
@@ -66,11 +66,11 @@ RSpec.describe RegexpExamples::ResultCountLimiters do
 
     context 'as a global setting' do
       before do
-        @original = RegexpExamples::ResultCountLimiters.max_repeater_variance
-        RegexpExamples::ResultCountLimiters.max_repeater_variance = 5
+        @original = RegexpExamples::Config.max_repeater_variance
+        RegexpExamples::Config.max_repeater_variance = 5
       end
       after do
-        RegexpExamples::ResultCountLimiters.max_repeater_variance = @original
+        RegexpExamples::Config.max_repeater_variance = @original
       end
 
       it 'sets limit without passing explicitly' do
@@ -94,11 +94,11 @@ RSpec.describe RegexpExamples::ResultCountLimiters do
 
     context 'as a global setting' do
       before do
-        @original = RegexpExamples::ResultCountLimiters.max_group_results
-        RegexpExamples::ResultCountLimiters.max_group_results = 10
+        @original = RegexpExamples::Config.max_group_results
+        RegexpExamples::Config.max_group_results = 10
       end
       after do
-        RegexpExamples::ResultCountLimiters.max_group_results = @original
+        RegexpExamples::Config.max_group_results = @original
       end
 
       it 'sets limit without passing explicitly' do
@@ -107,6 +107,5 @@ RSpec.describe RegexpExamples::ResultCountLimiters do
       end
     end
   end # describe 'max_group_results'
-
 
 end

--- a/spec/regexp-examples_spec.rb
+++ b/spec/regexp-examples_spec.rb
@@ -316,24 +316,6 @@ RSpec.describe Regexp, '#examples' do
         end
       end
 
-      context 'max_repeater_variance config option' do
-        it do
-          expect(/a+/.examples(max_repeater_variance: 5))
-            .to match_array %w(a aa aaa aaaa aaaaa aaaaaa)
-        end
-        it do
-          expect(/a{4,8}/.examples(max_repeater_variance: 0))
-            .to eq %w(aaaa)
-        end
-      end
-
-      context 'max_group_results config option' do
-        it do
-          expect(/\d/.examples(max_group_results: 10))
-            .to match_array %w(0 1 2 3 4 5 6 7 8 9)
-        end
-      end
-
       context 'case insensitive' do
         it { expect(/ab/i.examples).to match_array %w(ab aB Ab AB) }
         it do
@@ -377,39 +359,4 @@ RSpec.describe Regexp, '#examples' do
       end
     end # context 'exact examples match'
   end # context 'returns matching strings'
-
-  context 'max_results_limit config option' do
-    it 'with low limit' do
-      expect(/[A-Z]/.examples(max_results_limit: 5))
-        .to match_array %w(A B C D E)
-    end
-    it 'with (default) high limit' do
-      expect(/[ab]{14}/.examples.length)
-        .to be <= 10000 # NOT 2**14 == 16384, because it's been limited
-    end
-    it 'with (custom) high limit' do
-      expect(/[ab]{14}/.examples(max_results_limit: 20000).length)
-        .to eq 16384 # NOT 10000, because it's below the limit
-    end
-    it 'for boolean or groups' do
-      expect(/[ab]{3}|[cd]{3}/.examples(max_results_limit: 10).length)
-        .to eq 10
-    end
-    it 'for case insensitive examples' do
-      expect(/[ab]{3}/i.examples(max_results_limit: 10).length)
-        .to be <= 10
-    end
-    it 'for range repeaters' do
-      expect(/[ab]{2,3}/.examples(max_results_limit: 10).length)
-        .to be <= 10 # NOT 4 + 8 = 12
-    end
-    it 'for backreferences' do
-      expect(/([ab]{3})\1?/.examples(max_results_limit: 10).length)
-        .to be <= 10 # NOT 8 * 2 = 16
-    end
-    it 'for a complex pattern' do
-      expect(/(a|[bc]{2})\1{1,3}/.examples(max_results_limit: 14).length)
-        .to be <= 14 # NOT (1 + 4) * 3 = 15
-    end
-  end
 end

--- a/spec/result_count_limiters_spec.rb
+++ b/spec/result_count_limiters_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe RegexpExamples::ResultCountLimiters do
+
+  describe 'max_repeater_variance' do
+    context 'as a passed parameter' do
+      it 'with low limit' do
+        expect(/[A-Z]/.examples(max_results_limit: 5))
+          .to match_array %w(A B C D E)
+      end
+      it 'with (default) high limit' do
+        expect(/[ab]{14}/.examples.length)
+          .to be <= 10000 # NOT 2**14 == 16384, because it's been limited
+      end
+      it 'with (custom) high limit' do
+        expect(/[ab]{14}/.examples(max_results_limit: 20000).length)
+          .to eq 16384 # NOT 10000, because it's below the limit
+      end
+      it 'for boolean or groups' do
+        expect(/[ab]{3}|[cd]{3}/.examples(max_results_limit: 10).length)
+          .to eq 10
+      end
+      it 'for case insensitive examples' do
+        expect(/[ab]{3}/i.examples(max_results_limit: 10).length)
+          .to be <= 10
+      end
+      it 'for range repeaters' do
+        expect(/[ab]{2,3}/.examples(max_results_limit: 10).length)
+          .to be <= 10 # NOT 4 + 8 = 12
+      end
+      it 'for backreferences' do
+        expect(/([ab]{3})\1?/.examples(max_results_limit: 10).length)
+          .to be <= 10 # NOT 8 * 2 = 16
+      end
+      it 'for a complex pattern' do
+        expect(/(a|[bc]{2})\1{1,3}/.examples(max_results_limit: 14).length)
+          .to be <= 14 # NOT (1 + 4) * 3 = 15
+      end
+    end
+
+    context 'as a global setting' do
+      before do
+        @original = RegexpExamples::ResultCountLimiters.max_results_limit
+        RegexpExamples::ResultCountLimiters.max_results_limit = 5
+      end
+      after do
+        RegexpExamples::ResultCountLimiters.max_results_limit = @original
+      end
+
+      it 'sets limit without passing explicitly' do
+        expect(/[A-Z]/.examples)
+          .to match_array %w(A B C D E)
+      end
+    end
+  end # describe 'max_results_limit'
+
+  describe 'max_repeater_variance' do
+    context 'as a passed parameter' do
+      it 'with a larger value' do
+        expect(/a+/.examples(max_repeater_variance: 5))
+          .to match_array %w(a aa aaa aaaa aaaaa aaaaaa)
+      end
+      it 'with a lower value' do
+        expect(/a{4,8}/.examples(max_repeater_variance: 0))
+          .to eq %w(aaaa)
+      end
+    end
+
+    context 'as a global setting' do
+      before do
+        @original = RegexpExamples::ResultCountLimiters.max_repeater_variance
+        RegexpExamples::ResultCountLimiters.max_repeater_variance = 5
+      end
+      after do
+        RegexpExamples::ResultCountLimiters.max_repeater_variance = @original
+      end
+
+      it 'sets limit without passing explicitly' do
+        expect(/a+/.examples)
+          .to match_array %w(a aa aaa aaaa aaaaa aaaaaa)
+      end
+    end
+  end # describe 'max_repeater_variance'
+
+  describe 'max_group_results' do
+    context 'as a passed parameter' do
+      it 'with a larger value' do
+        expect(/\d/.examples(max_group_results: 10))
+          .to match_array %w(0 1 2 3 4 5 6 7 8 9)
+      end
+      it 'with a lower value' do
+        expect(/\d/.examples(max_group_results: 3))
+          .to match_array %w(0 1 2)
+      end
+    end
+
+    context 'as a global setting' do
+      before do
+        @original = RegexpExamples::ResultCountLimiters.max_group_results
+        RegexpExamples::ResultCountLimiters.max_group_results = 10
+      end
+      after do
+        RegexpExamples::ResultCountLimiters.max_group_results = @original
+      end
+
+      it 'sets limit without passing explicitly' do
+        expect(/\d/.examples)
+          .to match_array %w(0 1 2 3 4 5 6 7 8 9)
+      end
+    end
+  end # describe 'max_group_results'
+
+
+end


### PR DESCRIPTION
Add ability to globally define different result limiters, e.g.

```
RegexpExamples::Config.max_repeater_variance = 5
RegexpExamples::Config.max_group_results = 10
RegexpExamples::Config.max_results_limit = 20000
```