### PR TITLE
Use the dynamically called result type, not statically defined one

### DIFF
--- a/lib/regexp-examples/groups.rb
+++ b/lib/regexp-examples/groups.rb
@@ -125,7 +125,7 @@ module RegexpExamples
     # Generates the result of each contained group
     # and adds the filled group of each result to itself
     def result
-      strings = @groups.map { |repeater| repeater.public_send(__method__) }
+      strings = @groups.map { |repeater| repeater.public_send(__callee__) }
       RegexpExamples.permutations_of_strings(strings).map do |result|
         GroupResult.new(result, group_id)
       end


### PR DESCRIPTION
Fixes https://github.com/tom-lord/regexp-examples/issues/21

The subtle issue here is that `__method__` was referencing the **statically** defined method name (in this case, always `result`), whereas `__callee__` references the **dynamically** called method name (in this case, `random_result`).

Usually, `__callee__` is the same as `__method__`. But in some situations - such as here, where I've used `alias` - it's different.

The upshot of this is that previous versions of the gem may have had a limited results set to choose a "random example" from; in particular if the regex contained a "MultiGroup" (anything with brackets), and the number of possible results within those brackets was over 10,000 (the default [`max_results_limit`](https://github.com/tom-lord/regexp-examples#configuration-options)).