### PR TITLE
Fix warnings caused by Ruby 2.7 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.5.5
   - 2.6.2 # Uses unicode 12.0.0
   - 2.6.3 # Uses unicode 12.1.0
+  - 2.7.0
   - ruby-head
 matrix:
   allow_failures:

--- a/lib/core_extensions/regexp/examples.rb
+++ b/lib/core_extensions/regexp/examples.rb
@@ -5,13 +5,13 @@ module CoreExtensions
     # No core classes are extended in any way, other than the above two methods.
     module Examples
       def examples(**config_options)
-        RegexpExamples::Config.with_configuration(config_options) do
+        RegexpExamples::Config.with_configuration(**config_options) do
           examples_by_method(:result)
         end
       end
 
       def random_example(**config_options)
-        RegexpExamples::Config.with_configuration(config_options) do
+        RegexpExamples::Config.with_configuration(**config_options) do
           examples_by_method(:random_result).sample
         end
       end

--- a/lib/regexp-examples/config.rb
+++ b/lib/regexp-examples/config.rb
@@ -27,10 +27,10 @@ module RegexpExamples
         original_config = config.dup
 
         begin
-          self.config = new_config
+          update_config(**new_config)
           result = yield
         ensure
-          self.config = original_config
+          update_config(**original_config)
         end
 
         result
@@ -48,7 +48,7 @@ module RegexpExamples
 
       private
 
-      def config=(**args)
+      def update_config(**args)
         Thread.current[:regexp_examples_config].merge!(args)
       end
 

--- a/regexp-examples.gemspec
+++ b/regexp-examples.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '> 1.7'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'pry', '~> 0.12.0'
+  s.add_development_dependency 'warning', '~> 0.10.0'
   s.license          = 'MIT'
   s.required_ruby_version = '>= 2.4.0'
 end

--- a/spec/gem_helper.rb
+++ b/spec/gem_helper.rb
@@ -6,13 +6,14 @@ Coveralls.wear!
 require './lib/regexp-examples.rb'
 require 'helpers'
 require 'pry'
+require 'warning'
 
 # Several of these tests (intentionally) use "weird" regex patterns,
 # that spam annoying warnings when running.
 # E.g. warning: invalid back reference: /\k/
 # and  warning: character class has ']' without escape: /[]]/
 # This config disables those warnings.
-$VERBOSE = nil
+Warning.ignore(//, __dir__)
 
 RSpec.configure do |config|
   config.include Helpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ RSpec.configure do |config|
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
-  config.warnings = true
+  config.warnings = false
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an


### PR DESCRIPTION
Hi @tom-lord ,

I fixed following warnings caused by Ruby 2.7 update.

```
C:/Users/ishitani/workspace/regexp-examples/lib/core_extensions/regexp/examples.rb:8: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
C:/Users/ishitani/workspace/regexp-examples/lib/regexp-examples/config.rb:26: warning: The called method `with_configuration' is defined here
C:/Users/ishitani/workspace/regexp-examples/lib/regexp-examples/config.rb:30: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
C:/Users/ishitani/workspace/regexp-examples/lib/regexp-examples/config.rb:51: warning: The called method `config=' is defined here
C:/Users/ishitani/workspace/regexp-examples/lib/regexp-examples/config.rb:33: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
C:/Users/ishitani/workspace/regexp-examples/lib/regexp-examples/config.rb:51: warning: The called method `config=' is defined here
```

Could you please review my changes?